### PR TITLE
Update DefaultGridServiceManager.java

### DIFF
--- a/src/main/java/org/openspaces/admin/internal/gsm/DefaultGridServiceManager.java
+++ b/src/main/java/org/openspaces/admin/internal/gsm/DefaultGridServiceManager.java
@@ -375,8 +375,10 @@ public class DefaultGridServiceManager extends AbstractAgentGridComponent implem
         } catch (SecurityException se) {
             throw new AdminException("No privileges to relocate a processing unit instance "+ processingUnitInstance.getProcessingUnitInstanceName() , se);
         } catch (Exception e) {
-            String gsc = "GSC-"+gridServiceContainer.getAgentId()+"["+gridServiceContainer.getVirtualMachine().getDetails().getPid()+"]@" + gridServiceContainer.getMachine().getHostName();
-            throw new AdminException("Failed to relocate processing unit instance "+ processingUnitInstance.getProcessingUnitInstanceName() + " to " + gsc, e);
+            String gsc = gridServiceContainer == null
+            			? ""
+            			: (" to GSC-"+gridServiceContainer.getAgentId()+"["+gridServiceContainer.getVirtualMachine().getDetails().getPid()+"]@" + gridServiceContainer.getMachine().getHostName());
+            throw new AdminException("Failed to relocate processing unit instance "+ processingUnitInstance.getProcessingUnitInstanceName() + gsc, e);
         }
     }
 


### PR DESCRIPTION
Fixed NPE that happens when an error occurs during relocate in the case where the caller did not provide a gsc
