### PR TITLE
Support round bracket for PlaceholderReplacer

### DIFF
--- a/src/main/java/org/openspaces/core/util/PlaceholderReplacer.java
+++ b/src/main/java/org/openspaces/core/util/PlaceholderReplacer.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.openspaces.core.util;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Map;
 import org.springframework.util.PropertyPlaceholderHelper;
 import org.springframework.util.PropertyPlaceholderHelper.PlaceholderResolver;
@@ -37,21 +39,30 @@ public class PlaceholderReplacer {
      *      or a place holder with no suitable value in 'variables'
      */
     public static String replacePlaceholders(final Map<String, String> variables, final String value) throws PlaceholderResolutionException {
-        PropertyPlaceholderHelper helper = new PropertyPlaceholderHelper("${","}");
-        return helper.replacePlaceholders(value, new PlaceholderResolver() {
-            public String resolvePlaceholder(String key) {
-                if (key.isEmpty()) {
-                    throw new PlaceholderResolutionException("Placeholder in '" + value + "' has to have a length of at least 1");
-                }
-                
-                String result = variables.get(key);
-                if (result == null) {
-                    throw new PlaceholderResolutionException("Missing value for placeholder: '" + key + "' in '" + value + "'");
-                }
-                
-                return result;
-            }
-        });
+    	ArrayList<PropertyPlaceholderHelper> helpers = new ArrayList<PropertyPlaceholderHelper>(
+    			Arrays.asList(
+    					new PropertyPlaceholderHelper("${","}"),
+    					new PropertyPlaceholderHelper("$(",")")));
+    	
+    	String result = value;    	
+        for (PropertyPlaceholderHelper helper : helpers) {
+        	final String str = result;
+        	result = helper.replacePlaceholders(str, new PlaceholderResolver() {
+	            public String resolvePlaceholder(String key) {
+	                if (key.isEmpty()) {
+	                    throw new PlaceholderResolutionException("Placeholder in '" + str + "' has to have a length of at least 1");
+	                }
+	                
+	                String val = variables.get(key);
+	                if (val == null) {
+	                    throw new PlaceholderResolutionException("Missing value for placeholder: '" + key + "' in '" + str + "'");
+	                }
+	                
+	                return val;
+	            }
+	        });
+        }        
+        return result;
     }
     
     // this class extends RuntimeException so it can be thrown from PlaceholderResolver#resolvePlaceholder as done above

--- a/src/test/java/org/openspaces/itest/pu/container/servicegrid/PlaceholderReplacerTests.java
+++ b/src/test/java/org/openspaces/itest/pu/container/servicegrid/PlaceholderReplacerTests.java
@@ -38,6 +38,10 @@ public class PlaceholderReplacerTests extends TestCase {
         String template = wrap(key1);
         String result = PlaceholderReplacer.replacePlaceholders(env, template);
         Assert.assertEquals(value1, result);
+        
+        String templateRound = wrapRound(key1);
+        String resultRound = PlaceholderReplacer.replacePlaceholders(env, templateRound);
+        Assert.assertEquals(value1, resultRound);
     }
 
     public void test2() throws Exception {
@@ -50,6 +54,10 @@ public class PlaceholderReplacerTests extends TestCase {
         String template = wrap(key1) + wrap(key1);
         String result = PlaceholderReplacer.replacePlaceholders(env, template);
         Assert.assertEquals(value1 + value1, result);
+        
+        String templateRound = wrapRound(key1) + wrapRound(key1);
+        String resultRound = PlaceholderReplacer.replacePlaceholders(env, templateRound);
+        Assert.assertEquals(value1 + value1, resultRound);
     }
 
     public void test3() throws Exception {
@@ -64,6 +72,10 @@ public class PlaceholderReplacerTests extends TestCase {
         String template = wrap(key1) + filler + wrap(key1);
         String result = PlaceholderReplacer.replacePlaceholders(env, template);
         Assert.assertEquals(value1 + filler + value1, result);
+        
+        String templateRound = wrapRound(key1) + filler + wrapRound(key1);
+        String resultRound = PlaceholderReplacer.replacePlaceholders(env, templateRound);
+        Assert.assertEquals(value1 + filler + value1, resultRound);
     }
     
     public void test4() {
@@ -76,8 +88,8 @@ public class PlaceholderReplacerTests extends TestCase {
         String result = PlaceholderReplacer.replacePlaceholders(env, template);
         Assert.assertEquals("style", result);
         
-    }
-    
+    }    
+  
     public void testInvalid1() {
         String key1 = "VALUE";
         
@@ -111,5 +123,9 @@ public class PlaceholderReplacerTests extends TestCase {
 
     private static String wrap(String key) {
         return "${" + key + "}";
+    }
+    
+    private static String wrapRound(String key) {
+        return "$(" + key + ")";
     }
 }


### PR DESCRIPTION
Curly brackets are special characters in URL syntax according to [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#page-11).
Java compilation failure can occur if it is present in the Classpath section of the manifest file.
PlaceholderReplacer has to support other characters as placeholder in addition to curly brackets, e.g. round brackets in this pull request.